### PR TITLE
move AppAsideNav component to App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,22 +1,34 @@
 <template>
   <div id="app">
     <app-header :sections="sections"></app-header>
-    <transition name="fade" mode="out-in">
-      <router-view class="view"></router-view>
-    </transition>
+    <div :class="`app__container${ isLoginPage ? '--wide' : ''}`">
+      <aside class="app__aside" v-if="!isLoginPage">
+        <AppAsideNav/>
+      </aside>
+      <main class="app__main">
+        <transition name="fade" mode="out-in">
+          <router-view class="view"></router-view>
+        </transition>
+      </main>
+    </div>
   </div>
 </template>
 
 <script>
   import { SECTIONS_DEFAULT, } from './constants'
   import AppHeader from './components/AppHeader.vue'
+  import AppAsideNav from 'src/components/AppAsideNav.vue'
   export default {
     components: {
       'app-header': AppHeader,
+      AppAsideNav,
     },
     computed: {
       sections () {
         return SECTIONS_DEFAULT
+      },
+      isLoginPage () {
+        return this.$route.path === '/login'
       },
     },
     mounted () {
@@ -26,6 +38,39 @@
 </script>
 
 <style lang="stylus">
+#app
+  background-color #e6e6e6
+  min-height 100vh
+
+$container
+  max-width 1200px
+  margin auto
+  padding calc(35px + 22.5px) 0
+  display flex
+.app
+  &__container
+    @extends $container
+    &--wide
+      @extends $container
+      max-width 100vw
+      padding 0
+      > .app__main
+        margin-left 0
+  &__aside
+    width 75px
+    height 100%
+    position sticky
+    // position fixed
+    top 57.5px
+    z-index 999
+  &__main
+    flex 1
+    margin-left 30px
+    // margin-right 30px
+    display flex
+    justify-content flex-start
+    align-items flex-start
+
 a
   text-decoration none
 
@@ -35,10 +80,10 @@ button
     cursor not-allowed
 .view
   // max-width 800px
-  margin 0 auto
+  // margin 0 auto
   position relative
   background-color #fff
-  padding-top 35px
+  // padding-top 35px
   &.locked
     width 100%
     height 100vh
@@ -71,13 +116,13 @@ button
 .backstage
   width 100%
   min-height 100vh
-  padding 35px 0 0 65px
+  // padding 35px 0 0 65px
   overflow hidden
   &-container
     width 950px
     height 100%
     margin 0 auto
-    padding 25px 0
+    // padding 25px 0
     overflow hidden
   &__aside
     position fixed

--- a/src/components/AppAsideNav.vue
+++ b/src/components/AppAsideNav.vue
@@ -1,9 +1,10 @@
 <template>
   <nav class="app-aside-nav">
-    <router-link to="/"><img class="app-aside-nav__logo" :src="[ isBackstage ? '/public/icons/readr-logo-backstage.svg' : '/public/icons/readr-logo-dark.svg' ]" alt=""></router-link>
+    <!-- <router-link to="/"><img class="app-aside-nav__logo" :src="[ isBackstage ? '/public/icons/readr-logo-backstage.svg' : '/public/icons/readr-logo-dark.svg' ]" alt=""></router-link> -->
+    <router-link to="/"><img class="app-aside-nav__logo" src="/public/icons/readr-logo-dark.svg" alt=""></router-link>
     <ol class="aside-navigation">
       <div class="aside-navigation__section--white">
-        <transition name="fade" mode="out-in">
+        <!-- <transition name="fade" mode="out-in"> -->
           <router-link
             :to="$route.path === '/hot' ? '/' : '/hot'"
             :class="`list-item aside-navigation__list-item-drawer`"
@@ -12,7 +13,7 @@
             @mouseout.native="isHoverFirstListItem = false">
             <span v-text="wording[$route.path === '/hot' ? 'chief-editor-talk' : 'hot-talk']"></span>
           </router-link>
-        </transition>
+        <!-- </transition> -->
         <router-link
           :to="$route.path === '/hot' ? '/hot' : '/'"
           :class="`list-item aside-navigation__list-item${$route.path === '/' || $route.path === '/hot' ? '--highlight' : ''}`"
@@ -98,6 +99,7 @@ $aside-navigation__list-item
   list-style-type none
   flex 1 1 auto
   font-size 18px
+  -webkit-font-smoothing: antialiased
   width 50px
   height 50px
   padding 0 7px
@@ -162,7 +164,10 @@ $aside-navigation__list-item-drawer
           border-top none !important
   &__list-item-drawer
     @extends $aside-navigation__list-item-drawer
-
+    & + .list-item
+      & > span
+        border-top none !important
+    
 .list-item
   position relative
   // transition opacity .25s

--- a/src/components/projects/ProjectsFigure.vue
+++ b/src/components/projects/ProjectsFigure.vue
@@ -3,7 +3,7 @@
     <div class="projects-figure__img" :style="{ 'backgroundImage': `url(${project.heroImage})` }"></div>
     <figcaption class="projects-figcaption">
       <div class="projects-figcaption__share">
-        <AppShareButton :shareUrl="'www.google.com.tw'" :direction="'down'"/>
+        <!-- <AppShareButton :shareUrl="'www.google.com.tw'" :direction="'down'"/> -->
       </div>
       <p class="projects-figcaption__date" v-text="updatedAtYYYYMMDD(project.updatedAt)"></p>
       <h1 class="projects-figcaption__title" v-text="project.title"></h1>

--- a/src/views/ManageAdmin.vue
+++ b/src/views/ManageAdmin.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="backstage admin">
-    <AppAsideNav class="backstage__aside" />
-    <main class="backstage-container">
+    <div class="backstage-container">
       <About :profile="profile"></About>
       <template v-if="showMain">
         <TheControlBar
@@ -117,7 +116,7 @@
           </AlertPanel>
         </BaseLightBox>        
       </template>
-    </main>
+    </div>
   </div>
 </template>
 <script>
@@ -126,7 +125,6 @@
   import _ from 'lodash'
   import About from '../components/About.vue'
   import AlertPanel from '../components/AlertPanel.vue'
-  import AppAsideNav from '../components/AppAsideNav.vue'
   import AppHeader from '../components/AppHeader.vue'
   import BaseLightBox from '../components/BaseLightBox.vue'
   import FollowingListInTab from '../components/FollowingListInTab.vue'
@@ -278,7 +276,6 @@
       'app-tab': Tab,
       About,
       AlertPanel,
-      AppAsideNav,
       BaseLightBox,
       FollowingListInTab,
       MemberAccountEditor,
@@ -825,37 +822,3 @@
     },
   }
 </script>
-<style lang="stylus" scoped>
-  // .admin
-  //   background-color #e6e6e6
-  //   width 100%
-  //   min-height 100vh
-  //   &__container
-  //     max-width 1200px
-  //     margin auto
-  //     padding 25px 0
-  //     display flex
-  //   &__aside
-  //     width 75px
-  //     height 100%
-  //     position sticky
-  //     // position fixed
-  //     top 60px
-  //   &__main
-  //     margin-left 93.5px
-  //   .control-bar
-  //     width 100%
-  //     margin 0 auto
-  //   .panel
-  //     width 100%
-  //     padding 22px 84px 33px
-  //     border 5px solid #d8ca21
-  //     margin 0 auto
-  //     background-color white
-  // @media (min-width 950px)
-  //   .admin
-  //     .control-bar
-  //       max-width 950px
-  //     .panel
-  //       max-width 950px
-</style>

--- a/src/views/ManageEditor.vue
+++ b/src/views/ManageEditor.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="backstage editor">
-    <AppAsideNav class="backstage__aside" />
-    <main class="backstage-container">
+    <div class="backstage-container">
       <app-about :profile="profile"></app-about>
       <control-bar
         @addNews="$_editor_showEditor({ postPanel: 'add', postType: config.type.NEWS })"
@@ -71,7 +70,7 @@
           @publishPosts="$_editor_showAlert">
         </video-list>
       </template> -->
-    </main>
+    </div>
     <base-light-box :showLightBox.sync="showDraftList">
       <post-list-detailed
         :posts="postsDraft"
@@ -112,7 +111,6 @@
   import _ from 'lodash'
   import About from '../components/About.vue'
   import AlertPanelB from '../components/AlertPanel.vue'
-  import AppAsideNav from '../components/AppAsideNav.vue'
   import BaseLightBox from '../components/BaseLightBox.vue'
   import FollowingListInTab from '../components/FollowingListInTab.vue'
   import PostList from '../components/PostList.vue'
@@ -258,7 +256,6 @@
       'post-panel': PostPanelB,
       'tag-list': TagList,
       'video-list': VideoList,
-      AppAsideNav,
     },
     data () {
       return {
@@ -786,27 +783,6 @@
 </script>
 <style lang="stylus" scoped>
   .editor
-    width 100%
-    min-height 100vh
-    &__container
-      padding-top 37px
-    &__aside
-      display none
-      width 75px
-      height 100%
-      position sticky
-      // position fixed
-      top 60px
     &__record
       background-color #fff
-
-  @media (min-width 950px)
-    .editor
-      &__container
-        max-width 1200px
-        margin auto
-        padding 60px 0
-        display flex
-      &__aside
-        display block
 </style>

--- a/src/views/ManageGuestEditor.vue
+++ b/src/views/ManageGuestEditor.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="backstage guestEditor">
-    <AppAsideNav class="backstage__aside" />
-    <main class="backstage-container">
+    <div class="backstage-container">
       <app-about :profile="profile"></app-about>
       <control-bar
         @addNews="$_guestEditor_showEditor({ postPanel: 'add', postType: config.type.NEWS })"
@@ -35,7 +34,7 @@
           </following-list-tab>
         </app-tab>
       </template>
-    </main>
+    </div>
     <base-light-box :showLightBox.sync="showDraftList">
       <post-list-detailed
         :posts="postsDraft"
@@ -72,7 +71,6 @@
   import _ from 'lodash'
   import About from '../components/About.vue'
   import AlertPanel from '../components/AlertPanel.vue'
-  import AppAsideNav from '../components/AppAsideNav.vue'
   import AppHeader from '../components/AppHeader.vue'
   import BaseLightBox from '../components/BaseLightBox.vue'
   import FollowingListInTab from '../components/FollowingListInTab.vue'
@@ -156,7 +154,6 @@
       'post-list-detailed': PostListDetailed,
       'post-list-tab': PostListInTab,
       'post-panel': PostPanel,
-      AppAsideNav,
     },
     data () {
       return {
@@ -488,20 +485,6 @@
 </script>
 <style lang="stylus" scoped>
   .guestEditor
-    background-color #e6e6e6
-    width 100%
-    min-height 100vh
-    &__container
-      max-width 1200px
-      margin auto
-      padding 25px 0
-      display flex
-    &__aside
-      width 75px
-      height 100%
-      position sticky
-      // position fixed
-      top 60px
     &__record
       background-color #fff
 </style>

--- a/src/views/ManageMember.vue
+++ b/src/views/ManageMember.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="backstage member">
-    <aside-nav class="backstage__aside"></aside-nav>
-    <main class="backstage-container">
+    <div class="backstage-container">
       <app-about :profile="profile"></app-about>
       <app-tab class="backstage__tab" :tabs="tabs">
         <following-list-tab
@@ -12,13 +11,12 @@
           @unfollow="$_member_unfollow">
         </following-list-tab>
       </app-tab>
-    </main>
+    </div>
   </div>
 </template>
 <script>
   import { get, } from 'lodash'
   import About from '../components/About.vue'
-  import AppAsideNav from '../components/AppAsideNav.vue'
   import FollowingListInTab from '../components/FollowingListInTab.vue'
   import Tab from '../components/Tab.vue'
 
@@ -50,7 +48,6 @@
     components: {
       'app-about': About,
       'app-tab': Tab,
-      'aside-nav': AppAsideNav,
       'following-list-tab': FollowingListInTab,
     },
     data () {

--- a/src/views/PublicAbout.vue
+++ b/src/views/PublicAbout.vue
@@ -1,28 +1,21 @@
 <template>
   <div class="about">
     <div class="about__container">
-      <aside class="about__aside">
-        <app-aside-nav></app-aside-nav>
-      </aside>
-      <main class="about__main">
-        <app-tab class="about__tab" :tabs="tabs">
-          <article slot="0" class="about__content" v-html="aboutContent">
-          </article>
-        </app-tab>
-      </main>
+      <app-tab class="about__tab" :tabs="tabs">
+        <article slot="0" class="about__content" v-html="aboutContent">
+        </article>
+      </app-tab>
     </div>
   </div>
 </template>
 
 <script>
   import { ABOUT_CONTENT, } from '../constants/about'
-  import AppAsideNav from '../components/AppAsideNav.vue'
   import Tab from '../components/Tab.vue'
 
   export default {
     name: 'PublicAbout',
     components: {
-      'app-aside-nav': AppAsideNav,
       'app-tab': Tab,
     },
     data () {
@@ -41,7 +34,7 @@
     width 100%
     min-height 100vh
     &__container
-      padding-top 37px
+      padding-top 22.5px
     &__aside
       display none
       position sticky
@@ -62,19 +55,10 @@
   @media (min-width 950px)
     .about
       &__container
-        max-width 1200px
-        height 100%
-        margin auto
-        padding 60px 0
-        display flex
-      &__aside
-        display block
-      &__main
         display flex
         justify-content space-between
         align-items flex-start
         width 100%
-        margin-left 40px
       &__tab
         width 100%
         max-width 950px

--- a/src/views/PublicAgreement.vue
+++ b/src/views/PublicAgreement.vue
@@ -1,33 +1,23 @@
 <template>
   <div class="agreement">
-    <!-- <app-header></app-header> -->
     <div class="agreement__container">
-      <aside class="agreement__aside">
-        <AppAsideNav/>
-      </aside>
-      <main class="agreement__main">
-        <div class="terms">
-          <Tab :tabs="tabs">
-            <div slot="0" v-html="agreementContent" class="terms__member"></div>
-            <div slot="1">NA</div>
-            <div slot="2">NA</div>
-          </Tab>
-        </div>
-      </main>
+      <div class="terms">
+        <Tab :tabs="tabs">
+          <div slot="0" v-html="agreementContent" class="terms__member"></div>
+          <div slot="1">NA</div>
+          <div slot="2">NA</div>
+        </Tab>
+      </div>
     </div>
   </div>
 </template>
 <script>
   import { AGREEMENT_CONTENT, } from '../constants/agreement'
-  // import AppHeader from '../components/AppHeader.vue'
   import Tab from '../components/Tab.vue'
-  import AppAsideNav from '../components/AppAsideNav.vue'
 
   export default {
     components: {
-      // 'app-header': AppHeader,
       Tab,
-      AppAsideNav,
     },
     data () {
       return {
@@ -50,27 +40,12 @@
 </script>
 <style lang="stylus">
   .agreement
-    width 100%
-    background-color #e6e6e6
-    min-height 100vh
+    margin 0 auto
     &__container
-      max-width 1200px
       width 100%
-      margin auto
-      padding 25px 0
-      display flex
-    &__aside
-      width 75px
-      height 100%
-      position sticky
-      // position fixed
-      top 60px
-    &__main
-      margin-left 93.5px
-      width 100%
+      padding-top 22.5px
     .terms
       width 100%
-      margin 32px auto
       background-color white
       &__member
         h3

--- a/src/views/PublicEditors.vue
+++ b/src/views/PublicEditors.vue
@@ -1,26 +1,20 @@
 <template>
   <div class="editors">
     <div class="editors__container">
-      <aside class="editors__aside">
-        <AppAsideNav/>
-      </aside>
-      <main class="editors__main">
-        <AppTitledList :listTitle="$t('editors.WORDING_EDITORS_CURRENT_GUESTEDITOR')">
-          <ul class="editors-list-container">
-            <EditorsIntro class="editors-intro-main" v-for="customEditor in customEditors" :key="customEditor.id" :editor="customEditor"/>
-          </ul>
-        </AppTitledList>
-        <ul class="editors__list-aside">
-          <EditorsIntro class="editors-intro-aside" v-for="member in asideListMembers" :key="member.id" :editor="member" :trimDescription="true"/>
+      <AppTitledList :listTitle="$t('editors.WORDING_EDITORS_CURRENT_GUESTEDITOR')">
+        <ul class="editors-list-container">
+          <EditorsIntro class="editors-intro-main" v-for="customEditor in customEditors" :key="customEditor.id" :editor="customEditor"/>
         </ul>
-      </main>
+      </AppTitledList>
+      <ul class="editors__list-aside">
+        <EditorsIntro class="editors-intro-aside" v-for="member in asideListMembers" :key="member.id" :editor="member" :trimDescription="true"/>
+      </ul>
     </div>
   </div>
 </template>
 
 <script>
 import { ROLE_MAP, } from '../constants'
-import AppAsideNav from '../components/AppAsideNav.vue'
 import AppTitledList from '../components/AppTitledList.vue'
 import EditorsIntro from '../components/editors/EditorsIntro.vue'
 import _ from 'lodash'
@@ -55,7 +49,6 @@ export default {
   //   })
   // },
   components: {
-    AppAsideNav,
     AppTitledList,
     EditorsIntro,
   },
@@ -115,24 +108,7 @@ export default {
 
 <style lang="stylus" scoped>
 .editors
-  background-color #e6e6e6
-  min-height 100vh
   &__container
-    max-width 1200px
-    margin auto
-    padding 60px 0
-    display flex
-  &__aside
-    width 75px
-    height 100%
-    position sticky
-    // position fixed
-    top 60px
-    z-index 999
-  &__main
-    flex 1
-    margin-left 40px
-    margin-right 40px
     display flex
     justify-content flex-start
     align-items flex-start

--- a/src/views/PublicHome.vue
+++ b/src/views/PublicHome.vue
@@ -4,33 +4,28 @@
       <BaseLightBoxPost :showLightBox="showLightBox" :post="postLightBox"/>
     </BaseLightBox>
     <div class="homepage__container">
-      <aside class="homepage__aside">
-        <AppAsideNav></AppAsideNav>
-      </aside>
-      <main class="homepage__main">
-        <div class="homepage__list-main">
-          <div class="invitation">
-            <Invite></Invite>
-          </div>
-          <transition-group name="fade" mode="out-in">
-            <HomeArticleMain v-for="post in postsMain" :articleData="post" :key="`${post.id}-main`"/>
-          </transition-group>
+      <div class="homepage__list-main">
+        <div class="invitation">
+          <Invite></Invite>
         </div>
-        <div class="homepage__list-aside">
-          <AppTitledList :listTitle="sections['projects']">
-            <ul class="aside-list-container">
-              <HomeProjectAside />
-            </ul>
-          </AppTitledList>
-          <AppTitledList :listTitle="this.$route.path !== '/hot' ? sections['hot-talk'] : sections['chief-editor-talk']">
-            <ul class="aside-list-container">
-              <transition-group name="fade" mode="out-in">
-                <HomeArticleAside v-for="post in postsAside" :articleData="post" :key="`${post.id}-aside`"/>
-              </transition-group> 
-            </ul>
-          </AppTitledList>
-        </div>
-      </main>
+        <transition-group name="fade" mode="out-in">
+          <HomeArticleMain v-for="post in postsMain" :articleData="post" :key="`${post.id}-main`"/>
+        </transition-group>
+      </div>
+      <div class="homepage__list-aside">
+        <AppTitledList :listTitle="sections['projects']">
+          <ul class="aside-list-container">
+            <HomeProjectAside />
+          </ul>
+        </AppTitledList>
+        <AppTitledList :listTitle="this.$route.path !== '/hot' ? sections['hot-talk'] : sections['chief-editor-talk']">
+          <ul class="aside-list-container">
+            <transition-group name="fade" mode="out-in">
+              <HomeArticleAside v-for="post in postsAside" :articleData="post" :key="`${post.id}-aside`"/>
+            </transition-group> 
+          </ul>
+        </AppTitledList>
+      </div>
     </div>
   </div>   
 </template>
@@ -41,7 +36,6 @@ import { PROJECT_STATUS, } from '../../api/config'
 import { currEnv, isScrollBarReachBottom, isElementReachInView, isCurrentRoutePath, } from 'src/util/comm'
 import _ from 'lodash'
 import { createStore, } from '../store'
-import AppAsideNav from 'src/components/AppAsideNav.vue'
 import AppTitledList from 'src/components/AppTitledList.vue'
 import HomeProjectAside from 'src/components/home/HomeProjectAside.vue'
 import HomeArticleMain from 'src/components/home/HomeArticleMain.vue'
@@ -141,7 +135,6 @@ export default {
   //   }
   // },
   components: {
-    AppAsideNav,
     AppTitledList,
     HomeProjectAside,
     HomeArticleMain,
@@ -313,24 +306,7 @@ export default {
 
 <style lang="stylus" scoped>
 .homepage
-  background-color #e6e6e6
-  min-height 100vh
   &__container
-    max-width 1200px
-    margin auto
-    padding 25px 0
-    display flex
-  &__aside
-    width 75px
-    height 100%
-    position sticky
-    // position fixed
-    top 60px
-    z-index 999
-  &__main
-    flex 1
-    margin-left 30px
-    margin-right 30px
     display flex
     justify-content flex-end
     align-items flex-start

--- a/src/views/PublicLogin.vue
+++ b/src/views/PublicLogin.vue
@@ -14,13 +14,11 @@
   // import LoginPanel from '../components/LoginPanel.vue'
   import LoginPanelPackingTest from '../components/LoginPanelPackingTest.vue'
   import AppHeader from '../components/AppHeader.vue'
-  import AppAsideNav from '../components/AppAsideNav.vue'
   
   export default {
     components: {
       'app-header': AppHeader,
       LoginPanelPackingTest,
-      AppAsideNav,
     },
     computed: {
       isLoggedIn () {

--- a/src/views/PublicProfile.vue
+++ b/src/views/PublicProfile.vue
@@ -1,43 +1,38 @@
 <template>
   <div class="profile">
-    <aside class="profile__aside">
-      <AppAsideNav></AppAsideNav>
-    </aside>
-    <main class="profile__main">
-      <About v-if="profile" :profile="profile"></About>
-      <Tab class="profile__tab" :tabs="tabs">
-        <template slot="0" v-if="postsReview.length !== 0">
-          <div class="profile__main__review">
-            <div class="profile__main__review__filter">
-              <select @change="filterChanged">
-                <option v-text="$t('profile.WORDING_PROFILE_FILTER_ALL')" value="all"></option>
-                <option v-for="item in filters" v-text="item" :value="item"></option>
-              </select>
-            </div>
-            <div class="profile__main__review__container">
-              <div class="item" v-for="post in postsReview" :key="post.id">
-                <PostContent :modifier="'main'" :post="post"></PostContent>
-              </div>
+    <About v-if="profile" :profile="profile"></About>
+    <Tab class="profile__tab" :tabs="tabs">
+      <template slot="0" v-if="postsReview.length !== 0">
+        <div class="profile__main__review">
+          <div class="profile__main__review__filter">
+            <select @change="filterChanged">
+              <option v-text="$t('profile.WORDING_PROFILE_FILTER_ALL')" value="all"></option>
+              <option v-for="item in filters" v-text="item" :value="item"></option>
+            </select>
+          </div>
+          <div class="profile__main__review__container">
+            <div class="item" v-for="post in postsReview" :key="post.id">
+              <PostContent :modifier="'main'" :post="post"></PostContent>
             </div>
           </div>
-        </template>
-        <template :slot="postsReview.length !== 0 ? 1 : 0" v-if="postsNews.length !== 0">
-          <div class="profile__main__review">
-            <div class="profile__main__review__filter">
-              <select @change="filterChanged">
-                <option v-text="$t('profile.WORDING_PROFILE_FILTER_ALL')" value="all"></option>
-                <option v-for="item in filters" v-text="item" :value="item"></option>
-              </select>
-            </div>
-            <div class="profile__main__review__container">
-              <div class="item" v-for="post in postsNews" :key="post.id">
-                <PostContent :modifier="'main'" :post="post"></PostContent>
-              </div>
+        </div>
+      </template>
+      <template :slot="postsReview.length !== 0 ? 1 : 0" v-if="postsNews.length !== 0">
+        <div class="profile__main__review">
+          <div class="profile__main__review__filter">
+            <select @change="filterChanged">
+              <option v-text="$t('profile.WORDING_PROFILE_FILTER_ALL')" value="all"></option>
+              <option v-for="item in filters" v-text="item" :value="item"></option>
+            </select>
+          </div>
+          <div class="profile__main__review__container">
+            <div class="item" v-for="post in postsNews" :key="post.id">
+              <PostContent :modifier="'main'" :post="post"></PostContent>
             </div>
           </div>
-        </template>
-      </Tab>
-    </main>
+        </div>
+      </template>
+    </Tab>
   </div>
 </template>
 <script>
@@ -45,7 +40,6 @@
   import { ROLE_MAP, } from 'src/constants'
   import { find, filter, get, map, } from 'lodash'
   import About from 'src/components/About.vue'
-  import AppAsideNav from 'src/components/AppAsideNav.vue'
   import PostContent from 'src/components/PostContent.vue'
   import Tab from 'src/components/Tab.vue'
   import moment from 'moment'
@@ -91,7 +85,6 @@
     name: 'Profile',
     components: {
       About,
-      AppAsideNav,
       PostContent,
       Tab,
     },
@@ -255,21 +248,9 @@
 </script>
 <style lang="stylus" scoped>
   .profile
-    min-height 100vh
-    width 100%
-    background-color #e6e6e6
-    display flex
-    padding 35px 0 35px 75px
-    &__aside
-      position absolute
-      top 60px
-      left 0
-      width 75px
-      height 100%
+    width 950px
+    margin 0 auto
     &__main
-      width 950px
-      padding 25px 0 0 0
-      margin 0 auto
       &__review
         padding 0 100px
         &__filter

--- a/src/views/PublicProjects.vue
+++ b/src/views/PublicProjects.vue
@@ -1,36 +1,30 @@
 <template>
   <div class="projects-list">
     <div class="projects-list__container">
-      <aside class="projects-list__aside">
-        <AppAsideNav/>
-      </aside>
-      <main class="projects-list__main">
-        <div class="projects-list__list-main">
-          <ProjectsFigure v-for="project in projects" :project="project" :key="project.id"/>
-        </div>
-        <div class="projects-list__list-aside">
-          <!-- <ProjectsFigureProgress/>
-          <ProjectsFigureProgress/>
-          <AppTitledList :listTitle="$t('project.WORDING_PROJECT_HOT_KEYWORD')">
-            <ul class="projects-tags-hot-list-container">
-              <li class="projects-tags-hot-list-container__list">
-                <span class="projects-tags-hot-list-container__tag-name">原住民傳統領域</span>
-                <span class="projects-tags-hot-list-container__tag-count">7631</span>
-              </li>
-              <li class="projects-tags-hot-list-container__list">
-                <span class="projects-tags-hot-list-container__tag-name">農舍</span>
-                <span class="projects-tags-hot-list-container__tag-count">631</span>
-              </li>
-            </ul>
-          </AppTitledList> -->
-        </div>
-      </main>
+      <div class="projects-list__list-main">
+        <ProjectsFigure v-for="project in projects" :project="project" :key="project.id"/>
+      </div>
+      <div class="projects-list__list-aside">
+        <!-- <ProjectsFigureProgress/>
+        <ProjectsFigureProgress/>
+        <AppTitledList :listTitle="$t('project.WORDING_PROJECT_HOT_KEYWORD')">
+          <ul class="projects-tags-hot-list-container">
+            <li class="projects-tags-hot-list-container__list">
+              <span class="projects-tags-hot-list-container__tag-name">原住民傳統領域</span>
+              <span class="projects-tags-hot-list-container__tag-count">7631</span>
+            </li>
+            <li class="projects-tags-hot-list-container__list">
+              <span class="projects-tags-hot-list-container__tag-name">農舍</span>
+              <span class="projects-tags-hot-list-container__tag-count">631</span>
+            </li>
+          </ul>
+        </AppTitledList> -->
+      </div>
     </div>
   </div>
 </template>
 
 <script>
-import AppAsideNav from '../components/AppAsideNav.vue'
 import AppTitledList from '../components/AppTitledList.vue'
 import ProjectsFigure from '../components/projects/ProjectsFigure.vue'
 import ProjectsFigureProgress from '../components/projects/ProjectsFigureProgress.vue'
@@ -63,7 +57,6 @@ export default {
   //   return fetchProjectsList(store, {})
   // },
   components: {
-    AppAsideNav,
     AppTitledList,
     ProjectsFigure,
     ProjectsFigureProgress,
@@ -98,25 +91,7 @@ export default {
 
 <style lang="stylus" scoped>
 .projects-list
-  background-color #e6e6e6
-  min-height 100vh
   &__container
-    max-width 1200px
-    width 100%
-    margin auto
-    padding 25px 0
-    display flex
-  &__aside
-    width 75px
-    height 100%
-    position sticky
-    // position fixed
-    top 60px
-    z-index 999
-  &__main
-    flex 1
-    margin-left 40px
-    margin-right 40px
     display flex
   &__list-main
     display flex

--- a/src/views/PublicSearch.vue
+++ b/src/views/PublicSearch.vue
@@ -1,25 +1,19 @@
 <template>
   <div class="search">
     <div class="search__container">
-      <aside class="search__container__aside">
-        <AppAsideNav></AppAsideNav>
-      </aside>
-      <main class="search__container__main">
-        <SearchFilter @searchChange="searchChange"></SearchFilter>
-        <div v-if="currFilter === 'post'">
-          <HomeArticleMain v-for="(post, k) in items" :articleData="post" :key="`post-${k}`"></HomeArticleMain>
-        </div>
-        <div v-else-if="currFilter === 'conversation'"></div>
-        <div v-else>
-          <ProjectsFigure v-for="project in items" :project="project" :key="project.id"></ProjectsFigure>
-        </div>
-      </main>
+      <SearchFilter @searchChange="searchChange"></SearchFilter>
+      <div v-if="currFilter === 'post'">
+        <HomeArticleMain v-for="(post, k) in items" :articleData="post" :key="`post-${k}`"></HomeArticleMain>
+      </div>
+      <div v-else-if="currFilter === 'conversation'"></div>
+      <div v-else>
+        <ProjectsFigure v-for="project in items" :project="project" :key="project.id"></ProjectsFigure>
+      </div>
     </div>
   </div>
 </template>
 <script>
   import { filter, get, } from 'lodash'
-  import AppAsideNav from 'src/components/AppAsideNav.vue'
   import HomeArticleMain from 'src/components/home/HomeArticleMain.vue'
   import ProjectsFigure from 'src/components/projects/ProjectsFigure.vue'
   import SearchFilter from 'src/components/search/SearchFilter.vue'
@@ -55,7 +49,6 @@
     //   return fetchData(store, route)
     // },
     components: {
-      AppAsideNav,
       HomeArticleMain,
       ProjectsFigure,
       SearchFilter,
@@ -87,22 +80,10 @@
 </script>
 <style lang="stylus" scoped>
   .search
-    min-height 100vh
     &__container
-      max-width 1200px
-      margin auto
-      padding 25px 0
+      margin-left 40px
       display flex
-      &__aside
-        width 75px
-        height 100%
-        position sticky
-        top 60px
-        z-index 999
-      &__main
-        margin-left 40px
-        display flex
-        flex-direction column
-        justify-content flex-start
-        align-items flex-start
+      flex-direction column
+      justify-content flex-start
+      align-items flex-start
 </style>

--- a/src/views/PublicVideos.vue
+++ b/src/views/PublicVideos.vue
@@ -1,20 +1,14 @@
 <template>
   <div class="videos">
     <div class="videos__container">
-      <aside class="videos__aside">
-        <app-aside-nav></app-aside-nav>
-      </aside>
-      <main class="videos__main">
-        <videos-highlight :video="highlightVideo"></videos-highlight>
-        <videos-list ref="videosList" :hasMore="hasMore" :videos="videoList" @loadMore="$_videos_loadMore" @play="$_videos_changeHighlight"></videos-list>
-      </main>
+      <videos-highlight :video="highlightVideo"></videos-highlight>
+      <videos-list ref="videosList" :hasMore="hasMore" :videos="videoList" @loadMore="$_videos_loadMore" @play="$_videos_changeHighlight"></videos-list>
     </div>
   </div>
 </template>
 
 <script>
   import { filter, find, get, xor, } from 'lodash'
-  import AppAsideNav from '../components/AppAsideNav.vue'
   import VideosHighlight from '../components/videos/VideosHighlight.vue'
   import VideosList from '../components/videos/VideosList.vue'
 
@@ -49,7 +43,6 @@
       ])
     },
     components: {
-      AppAsideNav,
       VideosHighlight,
       VideosList,
     },
@@ -115,35 +108,13 @@
 </script>
 
 <style lang="stylus" scoped>
-  .videos
-    width 100%
-    min-height 100vh
-    &__container
-      padding-top 37px
-    &__aside
-      display none
-      position sticky
-      top 60px
-      width 75px
-      height 100%
   @media (min-width 950px)
     .videos
       &__container
-        max-width 1200px
-        height 100%
-        margin auto
-        padding 60px 0
-        display flex
-      &__aside
-        display block
-      &__main
         display flex
         justify-content space-between
         align-items flex-start
         width 100%
-        margin-left 40px
-      
-    
 </style>
 
 


### PR DESCRIPTION
* Remove every `<AppAsideNav/>` appearances and adjust template structures, styles in many components
* Move `AppAsideNav.vue` component to `App.vue` in order to keep the style consistent
* Hide transition animations while hovering on latest or hot section of `<AppAsideNav/>` due to style issue