### PR TITLE
resolve client is not matching SSR content issue when navigate to memo

### DIFF
--- a/src/components/BaseLightBoxPost.vue
+++ b/src/components/BaseLightBoxPost.vue
@@ -133,6 +133,8 @@ export default {
   },
   mounted () {
     this.isPostEmpty && (this.isContentEmpty = true)
+  },
+  created () {
     this.checkMemoStatus()
   },
   props: {


### PR DESCRIPTION
* Moving `this.checkMemoStatus()` to `created()` from `mounted()` in order to preserving `isContentEmpty` value consistent in `data()`