### PR TITLE
Switch to node:slim Docker

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 pipeline:
   start_slack:
     image: plugins/slack
-    channel: jenkins
+    channel: ground_control
     secrets: [slack_webhook]
     username: drone
     icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
@@ -23,11 +23,11 @@ pipeline:
     - cp default/readr-site/gcskeyfile.json ./gcskeyfile.json
     when:
       event: [push]
+  
   builds:
-    image: alpine:edge
+    image: node:8.12.0-slim
     commands:
-    - apk add --update --repository https://dl-3.alpinelinux.org/alpine/edge/testing/ python build-base make vips-dev fftw-dev nodejs-current yarn
-    - yarn global add node-gyp
+    - apt-get update && apt-get install -y node-gyp
     - yarn install
     - yarn run build
     when:
@@ -66,7 +66,7 @@ pipeline:
 
   finish_slack:
     image: plugins/slack
-    channel: jenkins
+    channel: ground_control
     secrets: [slack_webhook]
     username: drone
     icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 pipeline:
   start_slack:
     image: plugins/slack
-    channel: ground_control
+    channel: jenkins
     secrets: [slack_webhook]
     username: drone
     icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
@@ -13,6 +13,17 @@ pipeline:
       Someone gave *{{build.branch}}* a little push.
     when:
       event: [push]
+  
+  restore-cache:
+    image: drillster/drone-volume-cache
+    restore: true
+    mount:
+      - ./.yarn-cache
+      - ./node_modules
+    volumes:
+      - /tmp/cache:/cache
+    when:
+      branch: [master, dev]
   
   get_config:
     image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
@@ -33,7 +44,7 @@ pipeline:
     when:
       event: [push]
       branch: [master, dev]
-
+  
   publish:
     image: plugins/gcr
     repo: mirrormedia-1470651750304/${DRONE_REPO_NAME}
@@ -64,9 +75,20 @@ pipeline:
       event: [push]
       branch: dev
 
+  rebuild-cache:
+    image: drillster/drone-volume-cache
+    rebuild: true
+    mount:
+      - ./.yarn-cache
+      - ./node_modules
+    volumes:
+      - /tmp/cache:/cache
+    when:
+      branch: [master, dev]
+  
   finish_slack:
     image: plugins/slack
-    channel: ground_control
+    channel: jenkins
     secrets: [slack_webhook]
     username: drone
     icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ node_modules/
 # Yarn Integrity file
 .yarn-integrity
 
+# Vim
+*.swp
+
 # VisualStudioCode
 .vscode/*
 !.vscode/settings.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
-FROM alpine:edge
+FROM node:8.12.0-slim
 
 ENV NODE_SOURCE /usr/src
 
+RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
+
 WORKDIR $NODE_SOURCE
 
-RUN apk add --update --repository https://dl-3.alpinelinux.org/alpine/edge/testing/ python build-base make vips-dev fftw-dev \
-    && nodejs-current yarn
+RUN apt-get update \
+    && apt-get install -y node-gyp
+ 
+#RUN apk add --update --repository https://dl-3.alpinelinux.org/alpine/edge/testing/ python build-base make vips-dev fftw-dev \
+#    && nodejs-current yarn
 ADD . $NODE_SOURCE/
 # ADD default/readr-site/config.js $NODE_SOURCE/api/config.js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ WORKDIR $NODE_SOURCE
 RUN apt-get update \
     && apt-get install -y node-gyp
  
-#RUN apk add --update --repository https://dl-3.alpinelinux.org/alpine/edge/testing/ python build-base make vips-dev fftw-dev \
-#    && nodejs-current yarn
 ADD . $NODE_SOURCE/
 # ADD default/readr-site/config.js $NODE_SOURCE/api/config.js
 


### PR DESCRIPTION
It seems non-alpine linux have much stabler vips lib for the future usage of node-gyp and sharp. Considering this, in this pull request I tried to switch our stacks to node:slim version of Docker for stable support of theses libs.

In this pull request I also integrated drone cache function to speed up node_modules building. The effects await further observation.