### PR TITLE
Inplemented stage settings

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,27 +23,39 @@ pipeline:
     volumes:
       - /tmp/cache:/cache
     when:
-      branch: [master, dev]
+      branch: [dev, stage]
   
-  get_config:
+  get_dev_config:
     image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
     secrets: [google_credentials]
     commands:
-    - gcloud source repos clone default default
-    - cp default/readr-site/config.js api/
-    - cp default/readr-site/gcskeyfile.json ./gcskeyfile.json
+    - gcloud source repos clone default ../default
+    - cp ../default/readr-site/config.js ./api/
+    - cp ../default/keystone/gcskeyfile.json ./gcskeyfile.json
     when:
       event: [push]
+      branch: dev
   
-  builds:
-    image: node:8.12.0-slim
+  get_stage_config:
+    image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
+    secrets: [google_credentials]
     commands:
-    - apt-get update && apt-get install -y node-gyp
+    - gcloud source repos clone default ../default
+    - cp ../default/readr-site/stage/config.js ./api/
+    - cp ../default/readr-site/stage/.kube.yml ./.kube.yml
+    - cp ../default/keystone/gcskeyfile.json ./gcskeyfile.json
+    when:
+      event: [push]
+      branch: stage
+
+  builds:
+    image: gcr.io/mirrormedia-1470651750304/node:8.12.0-slim-gyp
+    commands:
     - yarn install
     - yarn run build
     when:
       event: [push]
-      branch: [master, dev]
+      branch: [dev, stage]
   
   publish:
     image: plugins/gcr
@@ -54,7 +66,7 @@ pipeline:
     secrets: [google_credentials]
     when:
       event: [push]
-      branch: [master, dev]
+      branch: [dev, stage]
   
   deploy_dev:
     image: nytimes/drone-gke:develop
@@ -75,6 +87,26 @@ pipeline:
       event: [push]
       branch: dev
 
+  deploy_stage:
+    image: nytimes/drone-gke:develop
+    zone: asia-east1-a
+    cluster: prod-readr
+    namespace: default
+    # For debugging
+    dry_run: false
+    verbose: true
+    secrets:
+      - source: google_credentials
+        target: token
+    vars:
+      image: gcr.io/mirrormedia-1470651750304/${DRONE_REPO_NAME}:${DRONE_COMMIT_AUTHOR}_${DRONE_COMMIT_BRANCH}_${DRONE_BUILD_NUMBER}
+      app: ${DRONE_REPO_NAME}
+      tier: frontend-stage
+      branch: stage
+    when:
+      event: [push]
+      branch: stage
+
   rebuild-cache:
     image: drillster/drone-volume-cache
     rebuild: true
@@ -84,7 +116,7 @@ pipeline:
     volumes:
       - /tmp/cache:/cache
     when:
-      branch: [master, dev]
+      branch: [dev, stage]
   
   finish_slack:
     image: plugins/slack

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.12.0-slim
+FROM gcr.io/mirrormedia-1470651750304/node:8.12.0-slim-gyp
 
 ENV NODE_SOURCE /usr/src
 
@@ -6,11 +6,7 @@ RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
 
 WORKDIR $NODE_SOURCE
 
-RUN apt-get update \
-    && apt-get install -y node-gyp
- 
 ADD . $NODE_SOURCE/
-# ADD default/readr-site/config.js $NODE_SOURCE/api/config.js
 
 EXPOSE 3000
 CMD ["yarn", "start"]


### PR DESCRIPTION
## Changelog
### stage flow
I modified `.drone.yml` and `Dockerfile` to support the deployment of stage counterpart of readr-site. When codes are merged into `stage` branch, drone will initiate the stage flow. There are steps different from `dev` flow:
1. It will download the `default/readr-site/stage/config.js` in `gcp` repo and use it as the config of readr-site. The `config.js` is almost identical to the version of production we are using in production, only the `API_HOST` is set to corresponding `readr-restful-stage`. Redis settings are the same as the production. 

2. It will also download the `default/readr-site/stage/.kube.yml`, and deploy a `readr-site-stage` to the kubernetes cluster we used for production. This `readr-site-stage` connect to a `readr-restful-stage`, and it uses different labels as the production version, so the production request will not reach here.
 
**Cautions: `stage` services are using the same redis and database as production. Any modification will be shared by production. Use with care.**

### Use customized node-gyp Docker
Installing node-gyp twice in build and publishing is too time-consuming. I created a customized node-gyp Docker in gcr, and use it as the basis of our building and publishing processes.