### PR TITLE
feat: remove iframe hostname restriction

### DIFF
--- a/src/util/post/config.js
+++ b/src/util/post/config.js
@@ -7,7 +7,6 @@ export const sanitizeHtmlOptions = {
     div: [ 'class', 'text' ],
     script: [ 'src' ]
   }),
-  allowedIframeHostnames: [ 'www.youtube.com', 'dev.readr.tw', 'www.readr.tw', 'cloud.highcharts.com', 'public.flourish.studio', 'quiz.tryinteract.com', 'plotdb.io', 'e.infogram.com', 'www.google.com', 'twitframe.com' ],
   allowedTags: [ 'img', 'strong', 'h1', 'h2', 'figcaption', 'em', 'blockquote', 'a', 'iframe', 'div', 'script', 'br', 'p' ],
   customContentBreakTagName: 'hr',
   transformTags: {

--- a/src/util/post/content.js
+++ b/src/util/post/content.js
@@ -6,7 +6,6 @@ const XMLSerializer = require('xmldom').XMLSerializer
 
 const {
   allowedAttributes,
-  allowedIframeHostnames,
   allowedTags,
   customContentBreakTagName,
   transformTags
@@ -16,7 +15,6 @@ export function getPostContentDOM (post) {
   const options = {
     allowedTags: false, // allow all tags
     allowedAttributes,
-    allowedIframeHostnames,
     selfClosing: [ 'img', customContentBreakTagName ],
     transformTags
   }
@@ -31,7 +29,6 @@ export function getPostContentStrings (post) {
   const options = {
     allowedTags,
     allowedAttributes,
-    allowedIframeHostnames,
     transformTags
   }
   const contentDOMChildNodes = get(getPostContentDOM(post), 'childNodes')


### PR DESCRIPTION
過去因為 READr 會有外人上稿，為了安全考量，有限制 iframe 的 hostname
但現在已經不開放外人使用，因此可把這個限制拿掉，省去每次手動添加新 hostname 的麻煩
readme、readr-site-mobile 也已一同修改